### PR TITLE
Use custom pre for blocks of code

### DIFF
--- a/src/how-to/build-a-chrome-extension-to-track-web-page-co2-emissions.html
+++ b/src/how-to/build-a-chrome-extension-to-track-web-page-co2-emissions.html
@@ -176,8 +176,10 @@
           compression levels, and rates, that are representative. For some
           sites, the resulting byte value may be high or low.
           <pre>
-            const compressionRate = getCompressionStrategy( requestType,
-            encoding, uncompressedBytes ).rate
+            <code>
+              const compressionRate = getCompressionStrategy( requestType,
+              encoding, uncompressedBytes ).rate
+            </code>
           </pre>
         </li>
         <li>

--- a/src/how-to/build-a-chrome-extension-to-track-web-page-co2-emissions.html
+++ b/src/how-to/build-a-chrome-extension-to-track-web-page-co2-emissions.html
@@ -175,10 +175,10 @@
           resources vary between sites due to server behaviour, so we select
           compression levels, and rates, that are representative. For some
           sites, the resulting byte value may be high or low.
-          <code>
+          <pre>
             const compressionRate = getCompressionStrategy( requestType,
             encoding, uncompressedBytes ).rate
-          </code>
+          </pre>
         </li>
         <li>
           <strong>Practice</strong>: Due to uncertainty around compression rates

--- a/src/styles/common.css
+++ b/src/styles/common.css
@@ -3,6 +3,7 @@
   --border-colour: #aaa;
   --visited-colour: #888;
   --bg-colour: #fff;
+  --box-colour: #f5f5f5;
   --accent-colour: #ffa502;
   --d: 0.25rem; /* 4px */
   --w: 100vw / 100;
@@ -62,6 +63,15 @@ blockquote {
 cite {
   display: block;
   margin: calc(var(--d) * 4) 0;
+}
+
+pre {
+  white-space: normal;
+  background-color: var(--box-colour);
+  padding: 0.5rem;
+  padding: 1em;
+  overflow-x: hidden;
+  word-wrap: break-word;
 }
 
 code {

--- a/src/styles/common.css
+++ b/src/styles/common.css
@@ -74,10 +74,6 @@ pre {
   word-wrap: break-word;
 }
 
-code {
-  white-space: pre-line;
-}
-
 blockquote *,
 cite *,
 code {


### PR DESCRIPTION
A small change but do you agree?

I've added styling (copied from Wikipedia) for the pre element to differentiate code blocks.