### PR TITLE
Fix validation failures on the good test card

### DIFF
--- a/src/accessibility/test-card.html
+++ b/src/accessibility/test-card.html
@@ -107,15 +107,15 @@
         </thead>
         <tbody>
           <tr>
-            <td scope="row">Chrome extension</td>
+            <td>Chrome extension</td>
             <td>Schema generation</td>
           </tr>
           <tr>
-            <td scope="row">Chrome extension</td>
+            <td>Chrome extension</td>
             <td>HTML validation</td>
           </tr>
           <tr>
-            <td scope="row">npm package</td>
+            <td>npm package</td>
             <td>
               <a href="https://github.com/danhartley/emissions"
                 >Emissions tracking</a


### PR DESCRIPTION
Small bug fix. 

`scope` should only be used on `th` elements (not `td` elements).

Discovered by running accessibility tests in an e2e test!